### PR TITLE
Resize image if size is not divisible by 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,6 @@ A nodelet calculate disparity from stereo image topic.
 ### Limitations
 
 - Disparity range is `[0, 127]`
-- Image width and height must be a divisible by 4
 
 ## Nodes 
 


### PR DESCRIPTION
sgm_gpu need to image size divisible by 4.

Then resize image width and height to divisible by 4 before stereo matching and restore it to original size at publishing.